### PR TITLE
Remove MatrixPath form dynamodb

### DIFF
--- a/src/5_Upload-to-aws.py
+++ b/src/5_Upload-to-aws.py
@@ -183,7 +183,6 @@ def main():
             "organism": config["organism"],
             "type": config["input"]["type"],
         },
-        "matrixPath": FILE_NAME,
         "cellSets": cellSets,
         "processingConfig": config_dataProcessing, 
     }


### PR DESCRIPTION
`MatrixPath` in the `experiments` table is not used any more: `{experimentId}/r.rds` is always used to access the matrix file. Do not set it when ingesting experiments.

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/460418/113559808-4e23c480-9602-11eb-945a-bb2bc53fd359.png">
