### PR TITLE
Fix seurat version

### DIFF
--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -214,8 +214,8 @@ config.doubletScores <- list(enabled="true", auto="true",
 identified.method <- ifelse(length(samples)==1, "unisample", "seuratv4")
 config.dataIntegration <- list(enabled="true", auto="true", 
     dataIntegration = list( method = identified.method , 
-                        methodSettings = list(seuratv4=list(numGenes=2000, normalisation="LogNormalize"), 
-                                            unisample=list(numGenes=2000, normalisation="LogNormalize"))),
+                        methodSettings = list(seuratv4=list(numGenes=2000, normalisation="logNormalize"), 
+                                            unisample=list(numGenes=2000, normalisation="logNormalize"))),
     dimensionalityReduction = list(method = "rpca", numPCs = 30, excludeGeneCategories = c())
 )
 

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -210,11 +210,11 @@ config.doubletScores <- list(enabled="true", auto="true",
     filterSettings = list(probabilityThreshold = 0.25, binStep = 0.05)
 )
 
-# BE CAREFUL! The method is based on config.json. For multisample only seuratv3, for unisample LogNormalize
-identified.method <- ifelse(length(samples)==1, "seuratv3", "unisample")
+# BE CAREFUL! The method is based on config.json. For multisample only seuratv4, for unisample LogNormalize
+identified.method <- ifelse(length(samples)==1, "unisample", "seuratv4")
 config.dataIntegration <- list(enabled="true", auto="true", 
     dataIntegration = list( method = identified.method , 
-                        methodSettings = list(seuratv3=list(numGenes=2000, normalisation="LogNormalize"), 
+                        methodSettings = list(seuratv4=list(numGenes=2000, normalisation="LogNormalize"), 
                                             unisample=list(numGenes=2000, normalisation="LogNormalize"))),
     dimensionalityReduction = list(method = "rpca", numPCs = 30, excludeGeneCategories = c())
 )

--- a/src/QC_helpers/dataIntegration.r
+++ b/src/QC_helpers/dataIntegration.r
@@ -83,7 +83,7 @@ run_dataIntegration <- function(scdata, config){
     umap_distance_metric <- "euclidean"
 
     # Currently, we only support Seurat V3 pipeline for the multisample integration
-   if(method=="seuratv3"){
+   if(method=="seuratv4"){
         data.split <- SplitObject(scdata, split.by = "type")
         for (i in 1:length(data.split)) {
             data.split[[i]] <- NormalizeData(data.split[[i]], normalization.method = normalisation, verbose = F)


### PR DESCRIPTION
`ifelse` had the arguments backwards and the pipeline now checks for `seuratv4` not `seuratv3`