### PR TITLE
Adding sample prefix to solve plot

### DIFF
--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -296,7 +296,7 @@ add_custom_config_per_sample <- function(step_fn, config, scdata, samples){
     result_config$auto <- NULL
     result_config$enabled <- NULL
     # Update config with the unisample thresholds
-    config[[sample]] <- result_config
+    config[[paste("sample-", sample, sep = "")]] <- result_config
   }
   
   return(config)

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -204,7 +204,7 @@ config.cellSizeDistribution <- list(enabled="true",
 
 config.mitochondrialContent <- list(enabled="true", auto="true", 
     filterSettings = list(method="absolute_threshold", methodSettings = list(
-        absolute_threshold=list(maxFraction=0.1, binStep=0.05)
+        absolute_threshold=list(maxFraction=10, binStep=0.05)
         )
     )
 )
@@ -227,14 +227,14 @@ config.doubletScores <- list(enabled="true", auto="true",
 
 # BE CAREFUL! The method is based on config.json. For multisample only seuratv4, for unisample LogNormalize
 identified.method <- ifelse(length(samples)==1, "unisample", "seuratv4")
-config.dataIntegration <- list(enabled="true", auto="true", 
+config.dataIntegration <- list(auto="true", 
     dataIntegration = list( method = identified.method , 
                         methodSettings = list(seuratv4=list(numGenes=2000, normalisation="logNormalize"), 
                                             unisample=list(numGenes=2000, normalisation="logNormalize"))),
     dimensionalityReduction = list(method = "rpca", numPCs = 30, excludeGeneCategories = c())
 )
 
-config.configureEmbedding <- list(enabled="true", auto="true", 
+config.configureEmbedding <- list(auto="true", 
     embeddingSettings = list(method = "umap", methodSettings = list(
                                 umap = list(minimumDistance=0.3, distanceMetric="euclidean"), 
                                 tsne = list(perplexity=min(30, ncol(seurat_obj)/100), learningRate=max(200, ncol(seurat_obj)/12))

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -204,7 +204,7 @@ config.cellSizeDistribution <- list(enabled="true",
 
 config.mitochondrialContent <- list(enabled="true", auto="true", 
     filterSettings = list(method="absolute_threshold", methodSettings = list(
-        absolute_threshold=list(maxFraction=10, binStep=0.05)
+        absolute_threshold=list(maxFraction=0.1, binStep=0.05)
         )
     )
 )

--- a/src/5_Upload-to-aws.py
+++ b/src/5_Upload-to-aws.py
@@ -50,7 +50,7 @@ def create_samples_table(config, experiment_id):
     else:
         samples = [ name for name in os.listdir("/input") if os.path.isdir(os.path.join("/input", name)) ]
     
-    samples_table["ids"] = [ sample for sample in samples]
+    samples_table["ids"] = [ "sample-"+sample for sample in samples]
 
     # For the current datasets it could happen that they are not in the gz format, so we leave the alternative tsv format. 
     mime_options = {"tsv": "application/tsv", "gz" : "application/gzip", "mtx" :  "application/mtx"}
@@ -79,7 +79,7 @@ def create_samples_table(config, experiment_id):
             }
 
         # Add the whole information to each sample
-        samples_table[sample] = {
+        samples_table["sample-"+sample] = {
             "name" : sample, 
             "uuid" : str(uuid.uuid4()), 
             "species": config["organism"],


### PR DESCRIPTION
Plots in dataProcessing don't work unless we add a prefix `sample` for ids in the samples-table as well as processConfig. 