### PR TITLE
hardcode dataIntegration method as seuratv4 and add unisample check

### DIFF
--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -226,7 +226,8 @@ config.doubletScores <- list(enabled="true", auto="true",
 )
 
 # BE CAREFUL! The method is based on config.json. For multisample only seuratv4, for unisample LogNormalize
-identified.method <- ifelse(length(samples)==1, "unisample", "seuratv4")
+# hardcoded because unisample check is performed in dataIntegration 
+identified.method <- 'seuratv4'
 config.dataIntegration <- list(auto="true", 
     dataIntegration = list( method = identified.method , 
                         methodSettings = list(seuratv4=list(numGenes=2000, normalisation="logNormalize"), 

--- a/src/QC_helpers/dataIntegration.r
+++ b/src/QC_helpers/dataIntegration.r
@@ -82,8 +82,11 @@ run_dataIntegration <- function(scdata, config){
     umap_min_distance <- 0.3
     umap_distance_metric <- "euclidean"
 
-    # Currently, we only support Seurat V3 pipeline for the multisample integration
-   if(method=="seuratv4"){
+    # temporary to make sure we don't run integration if unisample
+    nsamples <- length(unique(scdata$samples))
+    
+    # Currently, we only support Seurat V4 pipeline for the multisample integration
+    if(nsamples > 1 && method=="seuratv4"){
         data.split <- SplitObject(scdata, split.by = "type")
         for (i in 1:length(data.split)) {
             data.split[[i]] <- NormalizeData(data.split[[i]], normalization.method = normalisation, verbose = F)
@@ -93,6 +96,7 @@ run_dataIntegration <- function(scdata, config){
         scdata <- IntegrateData(anchorset = data.anchors, dims = 1:numPCs)
         DefaultAssay(scdata) <- "integrated"
     }else{
+        print('Only one sample detected.')
         # Else, we are in unisample experiment and we only need to normalize 
         scdata <- Seurat::NormalizeData(scdata, normalization.method = normalisation, verbose = F)
         scdata <-Seurat::FindVariableFeatures(scdata, selection.method = "vst", nfeatures = nfeatures, verbose = F)

--- a/src/QC_helpers/dataIntegration.r
+++ b/src/QC_helpers/dataIntegration.r
@@ -87,41 +87,29 @@ run_dataIntegration <- function(scdata, config){
     
     # Currently, we only support Seurat V4 pipeline for the multisample integration
     if(nsamples > 1 && method=="seuratv4"){
-        #FIX FOR CURRENT DATASET!!!!!!
-        Seurat::DefaultAssay(scdata) <- "RNA"
-        data.split <- Seurat::SplitObject(scdata, split.by = "samples")
+        data.split <- SplitObject(scdata, split.by = "type")
         for (i in 1:length(data.split)) {
-            data.split[[i]] <- Seurat::NormalizeData(data.split[[i]], normalization.method = normalization, verbose = F)
-            data.split[[i]] <- Seurat::FindVariableFeatures(data.split[[i]], selection.method = "vst", nfeatures = nfeatures, verbose = FALSE)
+            data.split[[i]] <- NormalizeData(data.split[[i]], normalization.method = normalisation, verbose = F)
+            data.split[[i]] <- FindVariableFeatures(data.split[[i]], selection.method = "vst", nfeatures = nfeatures, verbose = FALSE)
         }
-        data.anchors <- Seurat::FindIntegrationAnchors(object.list = data.split, dims = 1:numPCs, verbose = FALSE)
-
-        # @misc slots not preserved so transfer
-        misc <- scdata@misc
-        scdata <- Seurat::IntegrateData(anchorset = data.anchors, dims = 1:numPCs)
-        scdata@misc <- misc
-        Seurat::DefaultAssay(scdata) <- "integrated"
+        data.anchors <- FindIntegrationAnchors(object.list = data.split, dims = 1:numPCs, verbose = FALSE)
+        scdata <- IntegrateData(anchorset = data.anchors, dims = 1:numPCs)
+        DefaultAssay(scdata) <- "integrated"
     }else{
         print('Only one sample detected.')
         # Else, we are in unisample experiment and we only need to normalize 
-        scdata <- Seurat::NormalizeData(scdata, normalization.method = normalization, verbose = F)
+        scdata <- Seurat::NormalizeData(scdata, normalization.method = normalisation, verbose = F)
+        scdata <-Seurat::FindVariableFeatures(scdata, selection.method = "vst", nfeatures = nfeatures, verbose = F)
     }
-
-    scdata <- FindVariableFeatures(scdata, selection.method = "vst", assay = "RNA", nfeatures = nfeatures, verbose = FALSE)
-    vars <- HVFInfo(object = scdata, assay = "RNA", selection.method = 'vst') # to create vars
-    annotations <- scdata@misc[["gene_annotations"]]
-    vars$SYMBOL <- annotations$name[match(rownames(vars), annotations$input)]
-    vars$ENSEMBL <- rownames(vars)
-    scdata@misc[["gene_dispersion"]] <- vars
 
     # Scale in order to compute PCA
     scdata <- Seurat::ScaleData(scdata, verbose = F)
 
     # HARDCODE numPCs to 50
-    scdata <- Seurat::RunPCA(scdata, npcs = 50, features = Seurat::VariableFeatures(object=scdata), verbose=FALSE)
+    scdata <- Seurat::RunPCA(scdata, npcs = 50, features = VariableFeatures(object=scdata), verbose=FALSE)
 
     # Compute embedding with default setting to get an overview of the performance of the bath correction
-    scdata <- Seurat::RunUMAP(scdata, reduction='pca', dims = 1:numPCs, verbose = F, umap.method = "uwot-learn", min.dist = umap_min_distance, metric = umap_distance_metric)
+    scdata <- RunUMAP(scdata, reduction='pca', dims = 1:numPCs, verbose = F, umap.method = "uwot-learn", min.dist = umap_min_distance, metric = umap_distance_metric)
 
     return(scdata)
 }


### PR DESCRIPTION
Removing  the `unisample` flag for dataIntegration in dynamoDB resolves [BIOMAGE-780](https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-780).

These changes reflect that. I will run data-ingest locally with a unisample dataset (user#3) and these changes to verify that it is working.