### PR TITLE
Fix IDs, conversion and MT for multiple org

### DIFF
--- a/src/1_Preproc.r
+++ b/src/1_Preproc.r
@@ -93,11 +93,12 @@ create_dataframe <- function(config){
     }
 
     annotation_features <- list()
-# overall feature annotation is derived from input data saved in genes.tsv features.tsv.gz
-# since each sample only carries a subset of annotation for it's expressed genes, the annotation for all samples is merged.
-# this is an excerpt of features.tsv.gz
-# ENSG00000237613 | FAM138A | Gene Expression
-# ENSG00000186092 | OR4F5 | Gene Expression
+    # overall feature annotation is derived from input data saved in genes.tsv features.tsv.gz
+    # since each sample only carries a subset of annotation for it's expressed genes, the annotation for all samples is merged.
+    # this is an excerpt of features.tsv.gz
+    # ENSG00000237613 | FAM138A | Gene Expression
+    # ENSG00000186092 | OR4F5 | Gene Expression
+    # More information about enes.tsv features.tsv.gz: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/matrices
 
     for(sample in samples){
       sample_dir <- file.path('/input', sample)
@@ -111,10 +112,10 @@ create_dataframe <- function(config){
         )
       )
     }
-    annotation_features <- unique(do.call('rbind', annotation_features))
-    annotation_features <- annotation_features[, c(1, 2)]
-    colnames(annotation_features) <- c("input", "name")
-    write.table(annotation_features, "/output/features_annotations.tsv", sep = "\t", col.names = TRUE, row.names = FALSE, quote = FALSE)
+    annotation_features_df <- unique(do.call('rbind', annotation_features))
+    annotation_features_df <- annotation_features_df[, c(1, 2)]
+    colnames(annotation_features_df) <- c("input", "name")
+    write.table(annotation_features_df, "/output/features_annotations.tsv", sep = "\t", col.names = TRUE, row.names = FALSE, quote = FALSE)
   }
   
   # So far, we haven't tested input format in table type. 

--- a/src/1_Preproc.r
+++ b/src/1_Preproc.r
@@ -98,7 +98,7 @@ create_dataframe <- function(config){
     # this is an excerpt of features.tsv.gz
     # ENSG00000237613 | FAM138A | Gene Expression
     # ENSG00000186092 | OR4F5 | Gene Expression
-    # More information about enes.tsv features.tsv.gz: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/matrices
+    # More information about genes.tsv features.tsv.gz: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/matrices
 
     for(sample in samples){
       sample_dir <- file.path('/input', sample)

--- a/src/1_Preproc.r
+++ b/src/1_Preproc.r
@@ -92,14 +92,25 @@ create_dataframe <- function(config){
       "There should be the files {genes.tsv, matrix.mtx, barcodes.tsv} or {features.tsv.gz, barcodes.tsv.gz and matrix.mtx.gz}")
     }
 
+    annotation_features <- list()
+
     for(sample in samples){
-      scdata[[sample]] <- Read10X(paste("/input", sample, sep = "/"))  
+      scdata[[sample]] <- Read10X(paste("/input", sample, sep = "/"), gene.column = 1)  
+      if(file.exists(paste("/input", sample, "genes.tsv", sep = "/"))) 
+        annotation_features[[sample]] <- read.delim(paste("/input", sample, "genes.tsv", sep = "/"), header = FALSE)
+      if(file.exists(paste("/input", sample, "features.tsv.gz", sep = "/"))) 
+        annotation_features[[sample]] <- read.delim(paste("/input", sample, "features.tsv.gz", sep = "/"), header = FALSE)
       message(
         paste(
           "Found", nrow(scdata[[sample]]), "genes and", ncol(scdata[[sample]]), "cells in sample", sample, "."
         )
       )
     }
+    saveRDS(annotation_features, "/output/annotation_features.RDS")
+    annotation_features <- unique(do.call('rbind', annotation_features))
+    annotation_features <- annotation_features[, c(1, 2)]
+    colnames(annotation_features) <- c("input", "name")
+    write.table(annotation_features, "/output/features_annotations.tsv", sep = "\t", col.names = TRUE, row.names = FALSE, quote = FALSE)
   }
   
   # So far, we haven't tested input format in table type. 

--- a/src/1_Preproc.r
+++ b/src/1_Preproc.r
@@ -93,6 +93,11 @@ create_dataframe <- function(config){
     }
 
     annotation_features <- list()
+# overall feature annotation is derived from input data saved in genes.tsv features.tsv.gz
+# since each sample only carries a subset of annotation for it's expressed genes, the annotation for all samples is merged.
+# this is an excerpt of features.tsv.gz
+# ENSG00000237613 | FAM138A | Gene Expression
+# ENSG00000186092 | OR4F5 | Gene Expression
 
     for(sample in samples){
       sample_dir <- file.path('/input', sample)

--- a/src/1_Preproc.r
+++ b/src/1_Preproc.r
@@ -106,7 +106,6 @@ create_dataframe <- function(config){
         )
       )
     }
-    saveRDS(annotation_features, "/output/annotation_features.RDS")
     annotation_features <- unique(do.call('rbind', annotation_features))
     annotation_features <- annotation_features[, c(1, 2)]
     colnames(annotation_features) <- c("input", "name")

--- a/src/1_Preproc.r
+++ b/src/1_Preproc.r
@@ -95,11 +95,11 @@ create_dataframe <- function(config){
     annotation_features <- list()
 
     for(sample in samples){
-      scdata[[sample]] <- Read10X(paste("/input", sample, sep = "/"), gene.column = 1)  
-      if(file.exists(paste("/input", sample, "genes.tsv", sep = "/"))) 
-        annotation_features[[sample]] <- read.delim(paste("/input", sample, "genes.tsv", sep = "/"), header = FALSE)
-      if(file.exists(paste("/input", sample, "features.tsv.gz", sep = "/"))) 
-        annotation_features[[sample]] <- read.delim(paste("/input", sample, "features.tsv.gz", sep = "/"), header = FALSE)
+      sample_dir <- file.path('/input', sample)
+      scdata[[sample]] <- Read10X(sample_dir, gene.column = 1)  
+      fpaths <- file.path(sample_dir, c('genes.tsv', 'features.tsv.gz'))
+      fpath <- fpaths[file.exists(fpaths)][1]
+      if (!is.na(fpath)) annotation_features[[sample]] <- read.delim(fpath, header = FALSE)
       message(
         paste(
           "Found", nrow(scdata[[sample]]), "genes and", ncol(scdata[[sample]]), "cells in sample", sample, "."

--- a/src/3_Seurat.r
+++ b/src/3_Seurat.r
@@ -61,10 +61,12 @@ adding_metrics_and_annotation <- function(scdata, sample, config, min.cells = 3,
     message("[", sample, "] \t finding genome annotations for genes...")
     organism <- config$organism
 
-    annotations <- gprofiler2::gconvert(
-    query = rownames(seurat_obj), organism = organism, target="ENSG", mthreshold = Inf, filter_na = FALSE)
+    #annotations <- gprofiler2::gconvert(
+    #query = rownames(seurat_obj), organism = organism, target="ENSG", mthreshold = Inf, filter_na = FALSE)
 
-    if(organism%in%c("hsapiens", "mmusculus")){
+    annotations <- read.delim("/output/features_annotations.tsv")
+
+    if(any(grepl("^mt-", annotations$name, ignore.case = T))){
         message("[", sample, "] \t Adding MT information...")
         mt.features <-  annotations$input[grep("^mt-", annotations$name, ignore.case = T)]
         seurat_obj <- PercentageFeatureSet(seurat_obj, features=mt.features , col.name = "percent.mt")

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -61,9 +61,9 @@ annotations <- read.delim("/output/features_annotations.tsv")
 
 # In order to avoid duplicated genes names, we are going to add the ENSEMBL ID for those 
 # genes that are duplicated (geneNameDuplicated-ENSEMBL)
-duplicated_gene_name <- unique(annotations$name[duplicated(annotations$name)])
-idt_duplicated <- annotations$name %in% duplicated_gene_name
-annotations$name[idt_duplicated] <- paste(annotations$name[idt_duplicated], annotations$input[idt_duplicated], sep = "-")
+gname <- annotations$name
+is.dup <- duplicated(gname) | duplicated(gname, fromLast=TRUE)
+annotations$name[is.dup] <- paste(gname[is.dup], annotations$input[is.dup], sep = " - ")
 
 seurat_obj@misc[["gene_annotations"]] <- annotations
 
@@ -342,5 +342,4 @@ message("config file...")
 write(exportJson, "/output/config_dataProcessing.json")
 
 message("Step 4 completed.")
-
 

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -69,6 +69,7 @@ annotations$name[is.dup] <- paste(gname[is.dup], annotations$input[is.dup], sep 
 
 # Ensure index by rownames in seurat_obj
 annotations <- annotations[match(rownames(seurat_obj), annotations$input), ]
+rownames(annotations) <- annotations$input
 
 seurat_obj@misc[["gene_annotations"]] <- annotations
 

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -58,6 +58,13 @@ organism <- config$organism
 #annotations <- gprofiler2::gconvert(
 #query = rownames(seurat_obj), organism = organism, target="ENSG", mthreshold = Inf, filter_na = FALSE)
 annotations <- read.delim("/output/features_annotations.tsv")
+
+# In order to avoid duplicated genes names, we are going to add the ENSEMBL ID for those 
+# genes that are duplicated (geneNameDuplicated-ENSEMBL)
+duplicated_gene_name <- unique(annotations$name[duplicated(annotations$name)])
+idt_duplicated <- annotations$name %in% duplicated_gene_name
+annotations$name[idt_duplicated] <- paste(annotations$name[idt_duplicated], annotations$input[idt_duplicated], sep = "-")
+
 seurat_obj@misc[["gene_annotations"]] <- annotations
 
 message("Storing cells id...")

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -55,8 +55,9 @@ if (length(seurat_obj_list)==1){
 
 message("Storing gene annotations...")
 organism <- config$organism
-annotations <- gprofiler2::gconvert(
-query = rownames(seurat_obj), organism = organism, target="ENSG", mthreshold = Inf, filter_na = FALSE)
+#annotations <- gprofiler2::gconvert(
+#query = rownames(seurat_obj), organism = organism, target="ENSG", mthreshold = Inf, filter_na = FALSE)
+annotations <- read.delim("output/features_annotations.tsv")
 seurat_obj@misc[["gene_annotations"]] <- annotations
 
 message("Storing cells id...")

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -57,7 +57,7 @@ message("Storing gene annotations...")
 organism <- config$organism
 #annotations <- gprofiler2::gconvert(
 #query = rownames(seurat_obj), organism = organism, target="ENSG", mthreshold = Inf, filter_na = FALSE)
-annotations <- read.delim("output/features_annotations.tsv")
+annotations <- read.delim("/output/features_annotations.tsv")
 seurat_obj@misc[["gene_annotations"]] <- annotations
 
 message("Storing cells id...")

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -62,8 +62,13 @@ annotations <- read.delim("/output/features_annotations.tsv")
 # In order to avoid duplicated genes names, we are going to add the ENSEMBL ID for those 
 # genes that are duplicated (geneNameDuplicated-ENSEMBL)
 gname <- annotations$name
+# Keep original name in 'original_name' variable
+annotations$original_name <- gname
 is.dup <- duplicated(gname) | duplicated(gname, fromLast=TRUE)
 annotations$name[is.dup] <- paste(gname[is.dup], annotations$input[is.dup], sep = " - ")
+
+# Ensure index by rownames in seurat_obj
+annotations <- annotations[match(rownames(seurat_obj), annotations$input), ]
 
 seurat_obj@misc[["gene_annotations"]] <- annotations
 


### PR DESCRIPTION
**Link to issue**

https://biomage.atlassian.net/browse/BIOMAGE-830?atlOrigin=eyJpIjoiY2ZkZWI3N2VjNWJkNGY0NWIzYzFiNDA3OGEyYzk0YmUiLCJwIjoiaiJ9

Anything else the reviewers should know about the changes here

More detail in [slack](https://this-is-biomage.slack.com/archives/C01CP46TJ0Z/p1618857091096200).

Tasks related to this PR:

- Fix rownames to use ENSEMBL instead of gene names (changes in 1-1_Preproc)
- Use raw annotation to convert ENSEMBL to gene symbol instead of gprofiler
- Grep for multiple organism (not only for mouse and hsapiens)
- Duplicated genes symbol have been concatenated with ENSEMBL id (e.g. `Muc2-ENSG12...`)