### PR TITLE
init CLUSTER_ENV with default to staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,11 @@ Chicken is `ggallus`,  Zebrafish is `drerio`, etc.
 `input` should not be modified for 10x data sets.
 
 5. Run: `CLUSTER_ENV=production docker-compose up --build` to upload to production. The default will
-upload to staging.
+upload to staging. 
+
+This process should have given you an Experiment-ID (EID) as an output and also uploaded 3 things:
+
+1. The experiment configuration in `json` format into **DynamoDB** table `experiments-{CLUSTER_ENV}` with the EID as `experimentId` partion key
+2. The sample configuration in `json` format into **DynamoDB** table `samples-{CLUSTER_ENV}` with the EID as `experimentId` partion key
+3. An `r.rds` object into **S3** this bucket:  `biomage-source-{CLUSTER_ENV}/{experiment_id}/r.rds`
+

--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ Chicken is `ggallus`,  Zebrafish is `drerio`, etc.
 
 `input` should not be modified for 10x data sets.
 
-5. Run: `docker-compose up --build`.
+5. Run: `CLUSTER_ENV=production docker-compose up --build` to upload to production. The default will
+upload to staging.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     build:
       target: prod
       context: .
+      args:
+        - CLUSTER_ENV=${CLUSTER_ENV-staging}
     volumes:
       - ./src:/data-ingest/src:cached
       - ./input:/input:cached

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,8 @@ services:
     build:
       target: prod
       context: .
-      args:
-        - CLUSTER_ENV=${CLUSTER_ENV-staging}
+    environment:
+      - CLUSTER_ENV=${CLUSTER_ENV-staging}
     volumes:
       - ./src:/data-ingest/src:cached
       - ./input:/input:cached

--- a/src/5_Upload-to-aws.py
+++ b/src/5_Upload-to-aws.py
@@ -19,6 +19,7 @@ from datetime import datetime
 import uuid
 
 COLOR_POOL = []
+CLUSTER_ENV = os.getenv('CLUSTER_ENV')
 
 with open("/data-ingest/src/color_pool.json") as f:
     COLOR_POOL = json.load(f)
@@ -212,7 +213,7 @@ def main():
 
     print("Experiment name is", config["name"])
 
-    FILE_NAME = f"biomage-source-production/{experiment_id}/r.rds"
+    FILE_NAME = f"biomage-source-{CLUSTER_ENV}/{experiment_id}/r.rds"
 
     experiment_data = {
         "apiVersion": "2.0.0-data-ingest-seurat-rds-automated",
@@ -240,7 +241,7 @@ def main():
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_access_key,
         region_name="eu-west-1",
-    ).Table("experiments-production")
+    ).Table(f"experiments-{CLUSTER_ENV}")
     dynamo.put_item(Item=experiment_data)
     
 
@@ -250,7 +251,7 @@ def main():
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_access_key,
         region_name="eu-west-1",
-    ).Table("samples-production")
+    ).Table(f"samples-{CLUSTER_ENV}")
     dynamo.put_item(Item=samples_data)
 
 
@@ -266,8 +267,14 @@ def main():
     with open("/output/experiment.rds", "rb") as f:
         s3.put_object(Body=f, Bucket=bucket, Key=key)
     
-    print("successful. experiment is now accessible at:")
-    print(f"https://scp.biomage.net/experiments/{experiment_id}/data-exploration")
+
+    if CLUSTER_ENV == "production":
+        print("successful. experiment is now accessible at:")
+        print(f"https://scp.biomage.net/experiments/{experiment_id}/data-exploration")
+        
+    elif CLUSTER_ENV == "staging":
+        print("successful. experiment uploaded to staging.")
+
 
 
 

--- a/src/5_Upload-to-aws.py
+++ b/src/5_Upload-to-aws.py
@@ -271,9 +271,9 @@ def main():
     if CLUSTER_ENV == "production":
         print("successful. experiment is now accessible at:")
         print(f"https://scp.biomage.net/experiments/{experiment_id}/data-exploration")
-        
+
     elif CLUSTER_ENV == "staging":
-        print("successful. experiment uploaded to staging.")
+        print(f"successful. Experiment ID: {experiment_id} uploaded to staging.")
 
 
 


### PR DESCRIPTION
This was something discused that we should default to uploading to staging where we can test first.

This PR exposes a `CLUSTER_ENV` environmental variable that can be set to either `staging` (default) or `production`.

This was tested locally when re-ingesting user#2 and user#1 data. It worked and allowed me to upload data to staging and production