### PR TITLE
Move cell sets to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ Chicken is `ggallus`,  Zebrafish is `drerio`, etc.
 `input` should not be modified for 10x data sets.
 
 5. Run: `docker-compose up --build`.
+
+By default this command will deploy to staging, to deploy to production run: `ENVIRONMENT=production docker-compose up --build`

--- a/src/5_Upload-to-aws.py
+++ b/src/5_Upload-to-aws.py
@@ -25,7 +25,12 @@ ENVIRONMENT = os.getenv("ENVIRONMENT", "staging")
 
 WARN_TXT_COL = "\033[93m"
 RESET_TXT_COL = '\033[0m'
+ERR_TXT_COL = '\033[91m'
 print(f"{WARN_TXT_COL}Deploying to {ENVIRONMENT}{RESET_TXT_COL}")
+
+if (not (ENVIRONMENT in ["staging", "production"])):
+    print(f"{ERR_TXT_COL}{ENVIRONMENT} does not exists{RESET_TXT_COL}")
+    exit(1)
 
 with open("/data-ingest/src/color_pool.json") as f:
     COLOR_POOL = json.load(f)


### PR DESCRIPTION
When uploading relevant data to the aws services, upload cellSets object to a particular s3 table cell-sets-{CLUSTER_ENV} instead of adding it to the experiments data in dynamodb.

This probably has things in common with https://github.com/biomage-ltd/data-ingest/pull/19/files, both have the cluster_env flag added.