### PR TITLE
Fix metadata and scrublet

### DIFF
--- a/src/3_Seurat.r
+++ b/src/3_Seurat.r
@@ -69,7 +69,11 @@ adding_metrics_and_annotation <- function(scdata, sample, config, min.cells = 3,
     if(any(grepl("^mt-", annotations$name, ignore.case = T))){
         message("[", sample, "] \t Adding MT information...")
         mt.features <-  annotations$input[grep("^mt-", annotations$name, ignore.case = T)]
-        seurat_obj <- PercentageFeatureSet(seurat_obj, features=mt.features , col.name = "percent.mt")
+        mt.features <- mt.features[mt.features %in% rownames(seurat_obj)]
+        if (length(mt.features)>0)
+            seurat_obj <- PercentageFeatureSet(seurat_obj, features=mt.features , col.name = "percent.mt")
+        else
+            seurat_obj$percent.mt <- 0
     }
 
     message("[", sample, "] \t Getting scrublet results...")

--- a/src/3_Seurat.r
+++ b/src/3_Seurat.r
@@ -70,7 +70,7 @@ adding_metrics_and_annotation <- function(scdata, sample, config, min.cells = 3,
         message("[", sample, "] \t Adding MT information...")
         mt.features <-  annotations$input[grep("^mt-", annotations$name, ignore.case = T)]
         mt.features <- mt.features[mt.features %in% rownames(seurat_obj)]
-        if (length(mt.features)>0)
+        if (length(mt.features))
             seurat_obj <- PercentageFeatureSet(seurat_obj, features=mt.features , col.name = "percent.mt")
         else
             seurat_obj$percent.mt <- 0
@@ -133,4 +133,3 @@ df_flag_filtered <- data.frame(samples=samples, flag_filtered=ifelse(flag_filter
 write.table(df_flag_filtered, "/output/df_flag_filtered.txt", col.names = TRUE, row.names = FALSE, sep = "\t", quote = FALSE)
 
 message("Step 3 completed.")
-

--- a/src/4_Prepare_experiment.r
+++ b/src/4_Prepare_experiment.r
@@ -172,7 +172,7 @@ if("metadata" %in% names(config)){
     write.table(
         metadata_dynamo,
         file = "/output/metadata-cells.csv",
-        quote = F, col.names = F, row.names = F,
+        quote = F, col.names = T, row.names = F,
         sep = "\t"
     )
 }


### PR DESCRIPTION
PR to fix the following errors:

- src/2-2_Compute-metrics_scrublet.py. The scrublet function reduces the dimension of the matrix to compute the doublet scores. It may happens that the final number of genes may be smaller than the number of PCAs. In this PR we avoid this possible error. 
- src/3_Seurat.r. It can happens that in a multisample experiment, the genes associated with a sample does not have MT genes, but the other samples yes. To avoid possible errors, we have include a 0 when it happens.  
- src/4_Prepare_experiment.r. Fix metadata bug regarding colnames